### PR TITLE
fix old fuction name refrence cleaning to general_cleaning

### DIFF
--- a/lib/functions/general/cleaning.sh
+++ b/lib/functions/general/cleaning.sh
@@ -1,4 +1,4 @@
-# cleaning <target>
+# general_cleaning <target>
 
 # target: what to clean
 # "make-atf" = make clean for ATF, if it is built.

--- a/lib/functions/main/default-build.sh
+++ b/lib/functions/main/default-build.sh
@@ -31,7 +31,7 @@ function main_default_build_single() {
 	fi
 
 	if [[ $CLEAN_LEVEL == *sources* ]]; then
-		cleaning "sources"
+		general_cleaning "sources"
 	fi
 
 	# Too many things being done. Allow doing only one thing. For core development, mostly.


### PR DESCRIPTION
# Description

looks like function name was changed.. had old reference

triggered via: `sudo ./compile.sh EXPERT=yes CLEAN_LEVEL=make-uboot,debs,sources`


home/lane/GIT/build/lib/functions/main/default-build.sh: line 34: cleaning: command not found
[💥]     👇👇👇 Showing logfile below 👇👇👇 [ /home/lane/GIT/build/.tmp/logs-de729650-a5fd-43e3-a013-87e7ea290779/004.000.prepare_host.log ]
[👉]    --> 🦋   15: 910353 - 910353 - 910353: ehBE: group:  [ <prepare_host> ]
[👉]    --> 🌱   15: 910353 - 910353 - 910353: ehBE: info: Preparing [ host ]
[👉]    --> 🐛   15: 910353 - 910353 - 910353: ehBE: debug: Determining best Armbian mirror to use [ via redirector ]
[👉]    --> 🐛   15: 910353 - 910353 - 910353: ehBE: debug: Obtaining Armbian mirror [ via https://redirect.armbian.com ]
[👉]    --> 🐛   15: 910353 - 910353 - 910353: ehBE: debug: Obtained Armbian mirror OK [ https://armbian.tnahosting.net/dl/ ]
[👉]    --> 🌱   15: 910353 - 910353 - 910353: ehBE: info: Build host OS release [ jammy ]
[👉]    --> 🌿   15: 910353 - 910353 - 910353: ehBE: other: Installing build dependencies [  ]
[👉]    --> 🐛   15: 910353 - 910353 - 910353: ehBE: debug: All host-side dependencies/packages already installed. [ Skipping host-hide install ]
[👉]    --> 🐸   15: 910353 - 910353 - 910353: ehBE: command: Command debug [ /bin/bash -e -o pipefail -c update-ccache-symlinks ]
[👉]    -->--> command run successfully after 0 seconds
[👉]    --> 🌱   15: 910353 - 910353 - 910353: ehBE: info: Syncing clock [ host ]
[👉]    --> 🐸   15: 910353 - 910353 - 910353: ehBE: command: Command debug [ /bin/bash -e -o pipefail -c ntpdate pool.ntp.org ]
[👉]     1 Oct 10:19:29 ntpdate[911524] adjust time server 50.205.244.37 offset +0.000254 sec
[👉]    -->--> command run successfully after 7 seconds
[👉]    --> 🌱   22: 910353 - 910353 - 910353: ehBE: info: Ignoring toolchains [ SKIP_EXTERNAL_TOOLCHAINS: yes ]
[👉]    --> 🦋   22: 910353 - 910353 - 910353: ehBE: group:  [ </prepare_host> in 7s ]
[👉]    --> 🧽   22: 910353 - 910353 - 910353: ehBE: trap: main_trap_handler [ ERR and 127 trap_manager_error_handled: ]
[👉]    [💥]     👆👆👆 Showing logfile above 👆👆👆 [ /home/lane/GIT/build/.tmp/logs-de729650-a5fd-43e3-a013-87e7ea290779/004.000.prepare_host.log ]
[💥] Error occurred [ code 127 at /home/lane/GIT/build/lib/functions/main/default-build.sh:34
   main_default_build_single() --> ./lib/functions/main/default-build.sh:34
              cli_entrypoint() --> ./lib/functions/cli/cli-entrypoint.sh:141
                        main() --> ./compile.sh:52