### PR TITLE
meson-s4t7: Use partitiontype=generic instead of initrd hack

### DIFF
--- a/config/boards/khadas-vim1s.wip
+++ b/config/boards/khadas-vim1s.wip
@@ -2,7 +2,7 @@
 BOARD_NAME="Khadas VIM1S" # don't confuse with VIM1 (S905X)
 BOARDFAMILY="meson-s4t7"
 KERNEL_TARGET="legacy"
-BOARD_MAINTAINER="rpardini"
+BOARD_MAINTAINER="rpardini viraniac"
 SERIALCON="ttyS0" # for vendor kernel
 # BOOT_FDT_FILE="amlogic/kvim1s.dtb" # unset on purpose: uboot auto-determines the DTB to use
 
@@ -11,4 +11,4 @@ BOOTCONFIG="kvim1s_defconfig"
 KHADAS_BOARD_ID="kvim1s" # used to compile the fip blobs
 
 # Use extlinux and u-boot-menu extension
-SRC_CMDLINE="console=tty0 console=ttyS0,921600 no_console_suspend earlycon=aml-uart,0xfe078000 meson-gx-mmc.caps2_quirks=mmc-hs400 mac=\\\${eth_mac} khadas.serial=\\\${usid}"
+SRC_CMDLINE="console=tty0 console=ttyS0,921600 no_console_suspend earlycon=aml-uart,0xfe078000 meson-gx-mmc.caps2_quirks=mmc-hs400 mac=\\\${eth_mac} khadas.serial=\\\${usid} partition_type=generic"

--- a/config/boards/khadas-vim4.wip
+++ b/config/boards/khadas-vim4.wip
@@ -11,4 +11,4 @@ BOOTCONFIG="kvim4_defconfig"
 KHADAS_BOARD_ID="kvim4" # used to compile the fip blobs
 
 # Use extlinux and u-boot-menu extension
-SRC_CMDLINE="console=tty0 console=ttyS0,921600 no_console_suspend earlycon=aml-uart,0xfe078000 mac=\\\${eth_mac} khadas.serial=\\\${usid}"
+SRC_CMDLINE="console=tty0 console=ttyS0,921600 no_console_suspend earlycon=aml-uart,0xfe078000 mac=\\\${eth_mac} khadas.serial=\\\${usid} partition_type=generic"

--- a/config/sources/families/meson-s4t7.conf
+++ b/config/sources/families/meson-s4t7.conf
@@ -86,25 +86,3 @@ function post_uboot_custom_postprocess__build_fip() {
 	run_host_command_logged bash fip/mk_script.sh "${KHADAS_BOARD_ID}" "${uboot_work_dir}"
 	return 0
 }
-
-# Inject "reload partition table" to workaround evil xxx from vendor kernel vs eMMC
-# This probably can be avoided when we understand the "offset" needed for oowow/krescue emmc images
-pre_customize_image__inject_initramfs_rereadpt() {
-	display_alert "$BOARD" "injecting initramfs rereadpt" "warn"
-	local script_file_dst="${SDCARD}/etc/initramfs-tools/scripts/local-top/rereadpt.sh"
-	cat <<- 'EOD' > "${script_file_dst}"
-	#!/bin/sh
-	PREREQ=""
-	case $1 in
-		prereqs)
-			echo "$PREREQ"
-			exit 0
-			;;
-	esac
-	echo 'Re-reading mmc partition table to workaround aml_emmc_partition_ops' 1>&2
-	blockdev --rereadpt /dev/mmcblk0 || true
-	blockdev --rereadpt /dev/mmcblk1 || true
-	exit 0
-	EOD
-	run_host_command_logged chmod -v +x "${script_file_dst}"
-}


### PR DESCRIPTION
Also added viraniac as maintainer for vim1s

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Jira reference number [AR-9999]

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
